### PR TITLE
Fix Wallpaper Screen Positions

### DIFF
--- a/.idea/.idea.WallpaperEx/.idea/git_toolbox_prj.xml
+++ b/.idea/.idea.WallpaperEx/.idea/git_toolbox_prj.xml
@@ -11,5 +11,10 @@
         <option name="enabled" value="true" />
       </CommitMessageValidationOverride>
     </option>
+    <option name="commitMessageValidationEnabledOverride">
+      <BoolValueOverride>
+        <option name="enabled" value="true" />
+      </BoolValueOverride>
+    </option>
   </component>
 </project>

--- a/WallpaperEx/Forms/SettingsForm.cs
+++ b/WallpaperEx/Forms/SettingsForm.cs
@@ -78,6 +78,7 @@ public partial class SettingsForm : Form
 
                 // Attach Form to Wallpaper
                 User32.SetParent(it.Handle, _drawingWorker);
+                it.Dock = DockStyle.Fill;
             });
         }
         else

--- a/WallpaperEx/Forms/WallpaperForm.cs
+++ b/WallpaperEx/Forms/WallpaperForm.cs
@@ -1,4 +1,5 @@
 using Microsoft.Web.WebView2.WinForms;
+using WallpaperEx.Native;
 
 namespace WallpaperEx.Forms;
 
@@ -11,6 +12,8 @@ public partial class WallpaperForm : Form
 
     public WallpaperForm()
     {
+        StartPosition = FormStartPosition.Manual;
+
         InitializeComponent();
         InitializeWebView();
     }
@@ -24,15 +27,34 @@ public partial class WallpaperForm : Form
         
         _webView.Source = new(Wallpaper);
 
-        ClientSize = new(CurrentScreen.Bounds.Width, CurrentScreen.Bounds.Height);
-        
-        var location = CurrentScreen.Bounds.Location;
-        if (location.X < 0 || location.Y < 0)
+        var primary = Screen.PrimaryScreen!;
+        ClientSize = new (CurrentScreen.Bounds.Width, CurrentScreen.Bounds.Height);
+
+        var x = primary.Bounds.Right + CurrentScreen.Bounds.Left;
+        var y = 0;
+        if (CurrentScreen.Bounds.Width > CurrentScreen.Bounds.Height)
         {
-            location = Screen.PrimaryScreen.Bounds.Location - (Size) location;
+            // get max height of all screens
+            var totalVerticalHeight = Screen.AllScreens.Where(it => it.Bounds.Width < it.Bounds.Height).Max(s => s.Bounds.Width);
+
+            y = 0;
         }
-        
-        Location = location;
+
+        Location = new Point(x, y);
+
+        var screenNum = Screen.AllScreens.ToList().IndexOf(CurrentScreen);
+        var lbl = new Label
+        {
+            Text = "Y " + Location.Y,
+            ForeColor = CurrentScreen == Screen.PrimaryScreen ? Color.Chartreuse :  Color.White,
+            BackColor = Color.Black,
+            Font = new Font("Segoe UI", 40),
+            Visible = true,
+            AutoSize = true,
+            Location = new Point(Width / 2, Height / 2),
+        };
+        Controls.Add(lbl);
+        lbl.BringToFront();
     }
 
     private void InitializeWebView()

--- a/WallpaperEx/Native/User32.cs
+++ b/WallpaperEx/Native/User32.cs
@@ -8,6 +8,10 @@ public static class User32
 
     public const int WM_SPAWN_WORKER = 0x052C;
 
+    public const int MONITOR_DEFAULTTONULL = 0;
+    public const int MONITOR_DEFAULTTOPRIMARY = 1;
+    public const int MONITOR_DEFAULTTONEAREST = 2;
+    
     #endregion
     
     #region Delegates
@@ -39,6 +43,34 @@ public static class User32
     [DllImport("user32.dll", EntryPoint = "GetDesktopWindow")]
     public static extern IntPtr GetDesktopWindow();
 
+    [DllImport("user32.dll")]
+    public static extern bool GetMonitorInfo(IntPtr hMonitor, ref MONITORINFOEX lpmi);
+    
+    [DllImport("user32.dll")]
+    public static extern IntPtr MonitorFromWindow(IntPtr hwnd, uint dwFlags);
+    
+    #endregion
+
+    #region Wrapper
+
+    
+    public static int GetMonitorRotation(IntPtr hWnd)
+    {
+        var hMonitor = MonitorFromWindow(hWnd, MONITOR_DEFAULTTONEAREST);
+        var mi = new MONITORINFOEX();
+        
+        mi.cbSize = Marshal.SizeOf(mi);
+        
+        GetMonitorInfo(hMonitor, ref mi);
+        
+        var cx = mi.rcMonitor.Right - mi.rcMonitor.Left;
+        var cy = mi.rcMonitor.Bottom - mi.rcMonitor.Top;
+
+        return cx == cy ? 0 : // Monitor is not rotated
+            cx > cy ? 90 : // Monitor is landscape rotated 90 degrees clockwise
+            180; // Monitor is portrait rotated 180 degrees clockwise
+    }
+
     #endregion
 }
 
@@ -52,6 +84,30 @@ public enum SendMessageTimeoutFlags : uint
     SMTO_ABORTIFHUNG = 0x2,
     SMTO_NOTIMEOUTIFNOTHUNG = 0x8,
     SMTO_ERRORONEXIT = 0x20
+}
+
+#endregion
+
+#region Structs
+
+[StructLayout(LayoutKind.Sequential)]
+public struct MONITORINFOEX
+{
+    public int cbSize;
+    public RECT rcMonitor;
+    public RECT rcWork;
+    public uint dwFlags;
+    [MarshalAs(UnmanagedType.ByValArray, SizeConst = 32)]
+    public char[] szDevice;
+}
+
+[StructLayout(LayoutKind.Sequential)]
+public struct RECT
+{
+    public int Left;
+    public int Top;
+    public int Right;
+    public int Bottom;
 }
 
 #endregion

--- a/WallpaperEx/Program.cs
+++ b/WallpaperEx/Program.cs
@@ -1,4 +1,6 @@
+using System.Net.Mime;
 using WallpaperEx.Forms;
+using WallpaperEx.Native;
 
 namespace WallpaperEx;
 
@@ -10,9 +12,9 @@ internal static class Program
     [STAThread]
     private static void Main()
     {
-        // To customize application configuration such as set high DPI settings or default font,
-        // see https://aka.ms/applicationconfiguration.
-        ApplicationConfiguration.Initialize();
+        Application.EnableVisualStyles();
+        Application.SetCompatibleTextRenderingDefault(false);
+        Application.SetHighDpiMode(HighDpiMode.PerMonitorV2);
         Application.Run(new SettingsForm());
     }
 }


### PR DESCRIPTION
# The Problem
Currently WallpaperEx had problems with several screen setups and wasnt able to calculate the positions correctly.
It only worked if the most left screen was set as the primary screen and every other screen were in landscape mode.

## Example (Old Version)
Green is the primary screen
![](https://user-images.githubusercontent.com/12973684/236814438-cdfc77cf-8534-47d5-992c-1eb5401a09ce.png)

## Example (This PR)
Now Setups like this are also supported
![](https://user-images.githubusercontent.com/12973684/236814577-c1ab002d-0130-4189-a3e7-a6e672c5eba8.png)

# The Fix
The fix was a complete rewrite of the position calculation.
The main problem to be tackled was that as soon as the form was attached as the child of the worker of the desktop background drawer the position got shifted by the workspace offset.
As soon as I figured that out the fix was quite easy to implement.

Included are also some code quality updates.

